### PR TITLE
Add .gitignore to ignore build artifacts and temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Build and development folders
+build/
+devel/
+install/
+log/
+
+# Temporary files
+*~
+*.swp
+
+# Python cache
+__pycache__/
+
+# System files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
 adding a .gitignore file to prevent build directories and temporary files from being committed.  This change will help keep the repository clean and is a common best practice.

