### PR TITLE
Add .gitignore for ROS/C++ development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+﻿# ROS build files
+build/
+install/
+log/
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+
+# System files
+.DS_Store
+*~


### PR DESCRIPTION
Closes #11

Adds a standard .gitignore file for ROS/C++ development to prevent tracking of:
- Build directories (build/, install/, log/)
- IDE files (.vscode/, .idea/)
- System files (.DS_Store, swap files)

This follows GitHub's ROS2 .gitignore template and common patterns from:
- https://github.com/ros2/ros2/blob/master/.gitignore
- https://github.com/github/gitignore/blob/main/ROS.gitignore